### PR TITLE
Add support for GDAL 2.0.

### DIFF
--- a/prepair.cpp
+++ b/prepair.cpp
@@ -132,8 +132,13 @@ int main (int argc, const char * argv[]) {
     
     //-- reading from a ogr dataset (most supported: shp, geojson, gml, etc)
     else if (strcmp(argv[argNum], "--ogr") == 0) {
+#if GDAL_VERSION_MAJOR < 2
       OGRRegisterAll();
       OGRDataSource *dataSource = OGRSFDriverRegistrar::Open(argv[argNum+1], false);
+#else
+      GDALAllRegister();
+      GDALDataset *dataSource = (GDALDataset*) GDALOpenEx(argv[argNum+1], GDAL_OF_READONLY, NULL, NULL, NULL);
+#endif
       ++argNum;
       if (dataSource == NULL) {
         std::cerr << "Error: Could not open file." << std::endl;


### PR DESCRIPTION
As reported in #22, prepair fails to build with GDAL 2.0

This PR forwards the changes added to the Debian package to build successfully with GDAL 2.0.1.

The code is kept as-is for GDAL 1.x, and alternatives are added for GDAL 2.x to build successfully with both.