### PR TITLE
Fix compatibility with CGAL>=5.0

### DIFF
--- a/PolygonRepair.h
+++ b/PolygonRepair.h
@@ -33,7 +33,8 @@ public:
   
 private:
   Triangulation triangulation;
-  
+
+  Triangulation::Constraint_id getConstraint(Triangulation::Vertex_handle va, Triangulation::Vertex_handle vb);
   void insertConstraints(Triangulation &triangulation, OGRGeometry *geometry, bool removeOverlappingConstraints = true);
   void tagOddEven(Triangulation &triangulation);
   void tagPointSet(Triangulation &triangulation, std::list<std::pair<bool, OGRMultiPolygon *> > &geometries);


### PR DESCRIPTION
Some functions of the constrained Delaunay triangulation were removed in CGAL 5.0 and made _prepair_ fail to compile using CGAL>=5.0.

This PR fixes it mainly by introducing a function `getContraint()` to recover the constraint ID from a pair of vertices.

__Note:__ while it compiles and mostly runs fine, there is most probably a problem with the parts that were called "hacks" and that consisted in inserting and then removing a constraint. I'm not sure why this was done and it's not clear to me if this was to address a bug in CGAL or something else. But I feel like something is broken here, because I get a different output for the example:

```
    $ ./prepair --isr 2 --wkt "POLYGON((0 0, 10 0, 15 5, 10 0, 10 10, 0 10, 0 0))"
    MULTIPOLYGON (((11 1,11 11,1 11,1 1,11 1)))
```

My output is:
```
MULTIPOLYGON (((0 0,10 0,10 10,0 10,0 0)))
```

The other examples seem to work fine but from what I've observed, they never go into the "hack" sections, which sort of confirms my feeling that these sections become problematic with my fix.